### PR TITLE
Add GISDK Python examples folder and iterative geocoding example

### DIFF
--- a/gisdk-examples/.gitignore
+++ b/gisdk-examples/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+.env

--- a/gisdk-examples/01_iterativeGeocoding/iterative_geocoding.py
+++ b/gisdk-examples/01_iterativeGeocoding/iterative_geocoding.py
@@ -1,0 +1,64 @@
+# Before running:
+# 1. Open Maptitude manually
+# 2. Open the ParcelInfo.bin table, located in the Tutorial folder:
+#    "C:\Users\[USERNAME]\Documents\Caliper\Maptitude 2025\Tutorial\ParcelInfo.bin"
+
+import caliperpy
+
+def (dk):
+    # try:
+        # Assume the view/table name is provided
+        view = dk.GetView()
+        out_folder = "c:\\temp\\"
+
+        # Create a Data.Geocoder object and set the region
+        geo = dk.CreateGisdkObject("gis_ui", "Data.Geocoder")
+        geo.SetRegion()
+        region_name = geo.GetRegionName()
+        print(f"Locating view {view} in region {region_name}")
+
+        # Get field specifications for the input view
+        id_field = dk.GetFieldFullSpec(view, "ID")
+        address_field = dk.GetFieldFullSpec(view, "Address")
+        postal_field = dk.GetFieldFullSpec(view, "ZIP")
+        city_field = dk.GetFieldFullSpec(view, "City")
+        state_field = dk.GetFieldFullSpec(view, "State")
+
+        # Define geocoding options
+        opts = {
+            "new_layer_name": view + "_Layer",
+            "out_db": out_folder + view + "_Layer.dbd"
+        }
+
+        # First pass: geocode by ADDRESS method using address and postal code
+        result = geo.LocateView("ADDRESS", view + "|", id_field, [address_field, None, postal_field], opts)
+        result_dict = dict(result)
+        layer_name = result_dict["LayerName"]
+        not_found_set = result_dict.get("NotFoundSet")
+
+        # Update field specs for the newly created layer
+        id_field = dk.GetFieldFullSpec(layer_name, "ID")
+        postal_field = dk.GetFieldFullSpec(layer_name, "ZIP")
+        city_field = dk.GetFieldFullSpec(layer_name, "City")
+        state_field = dk.GetFieldFullSpec(layer_name, "State")
+
+        # If some records were not found, try geocoding again by ADDRESS
+        if not_found_set is not None and layer_name is not None:
+            input_fields = [address_field, None, postal_field]
+            result = geo.LocateView("ADDRESS", view + "|", id_field, input_fields, opts)
+
+        # For any records still not found, try geocoding by CITY
+        not_found_set = result_dict.get("NotFoundSet")
+        if not_found_set is not None and layer_name is not None:
+            result = geo.LocateView("CITY", layer_name + "|" + not_found_set, id_field, [city_field, state_field], None)
+
+        print("Iterative geocoding result:", result)
+        return result
+
+    #except Exception as e:
+        print("Error during iterative geocoding:", e)
+
+# Example usage:
+if __name__ == "__main__":
+    dk = caliperpy.Maptitude.connect()
+    iterative_geocoding(dk)

--- a/gisdk-examples/01_iterativeGeocoding/readme.md
+++ b/gisdk-examples/01_iterativeGeocoding/readme.md
@@ -1,0 +1,54 @@
+# Example: Iterative Geocoding with GISDK + Python
+
+This example demonstrates how to **geocode a dataset iteratively** using the **Caliper Maptitude GISDK** via the `caliperpy` Python API.  
+The script processes a view or table containing address information and attempts to locate each record in **three passes**, saving unmatched records in **selection sets** for further review.
+
+---
+
+## How the Geocoding Passes Work
+
+### **Pass 1 — Address + ZIP**
+- Uses the **ADDRESS** method.
+- Attempts to locate each record using the **street address** and **postal code**.
+- Creates a **new geocoded layer** and automatically generates a **selection set** for **unmatched records**.
+
+### **Pass 2 — Retry Unmatched Records**
+- Processes the **selection set** of unmatched records from Pass 1.
+- Runs the **ADDRESS** method again using updated field specifications from the new layer.
+- Reduces the number of unlocated records.
+
+### **Pass 3 — City + State**
+- For records **still unmatched** after Pass 2:
+    - Uses the **CITY** method.
+    - Locates records based on **city** and **state** only, ignoring street addresses.
+    - Maximizes the overall match rate when only partial data is available.
+
+---
+
+## Inputs
+
+- A Maptitude **view or table** with:
+  - Address
+  - ZIP (postal code)
+  - City
+  - State
+- **Maptitude 2025 or newer** with GISDK installed and licensed.
+- `caliperpy` Python library installed.
+- Access to the **Maptitude Tutorial data** (if required by the script).
+
+---
+
+## Outputs
+
+- A **new geocoded layer** saved as a `.dbd` database file in the output folder (default: `C:\temp\`).
+- The new layer contains a selection set  **(NotFoundSet)** containing the records that could **not** be geocoded.
+
+---
+
+## How to Run
+1. Open Maptitude manually
+2. Open the ParcelInfo.bin table, located in the Tutorial folder:
+    "C:\Users\[USERNAME]\Documents\Caliper\Maptitude YYYY\Tutorial\ParcelInfo.bin"
+
+```bash
+python Geocoding.py

--- a/gisdk-examples/readme.md
+++ b/gisdk-examples/readme.md
@@ -1,0 +1,37 @@
+# Maptitude GISDK Python Examples
+
+This folder contains Python examples demonstrating how to integrate  Caliper Maptitude GISDK with Python.  
+Each example focuses on a specific workflow or functionality and is organized in its own dedicated subfolder.
+
+## Folder Structure
+
+- **<01_exmaple>/** A Subfolder containing a single Python script and any related files.
+- **<02_example>/**  Another example with its own script.
+- **<NN_example>/**  Additional examples will follow the same structure.
+
+> **Note:** Each subfolder corresponds to a **single Python script** demonstrating a specific GISDK use case.
+
+## Data Requirements
+
+- caliperpy
+- These examples **do not include local datasets**.
+- All scripts use sample data provided in the **Maptitude Tutorial** folder that comes pre-installed with Maptitude.
+- Ensure the Maptitude Tutorial data is installed and accessible on your system.
+
+## Usage
+
+1. Navigate to the subfolder of the example you want to run.
+2. Open the Python script inside the subfolder.
+3. Follow the instructions provided in the script comments.
+
+## Dependencies
+
+- **Python 3.9+** (recommended)
+- Maptitude 2025 or a later version, TransCAD 9.0 or later.
+- Datasets in the C:\Users\[USERNAME]\Documents\Caliper\Maptitude YYYY\Tutorial  folder.  
+
+## Notes
+
+- These examples are designed for **educational purposes** and can be adapted for production workflows.
+- To learn about Maptitude GISDK refer to: [https://www.caliper.com/learning](https://www.caliper.com/learning)
+- For full GISDK documentation, refer to: [https://www.caliper.com/learning/gis-development-kit](https://www.caliper.com/learning/gis-development-kit)

--- a/gisdk-examples/requirements.txt
+++ b/gisdk-examples/requirements.txt
@@ -1,0 +1,1 @@
+caliperpy


### PR DESCRIPTION
## Summary
Added a new `gisdk-examples/` directory containing Python examples for **Maptitude GISDK** integration via the `caliperpy` API.

## Changes
- Added `gisdk-examples/` top-level folder.
- Added `01_iterativeGeocoding/` with:
    - `iterative_geocoding.py`: Demonstrates iterative geocoding using three passes.
    - `README.md`: Explains the geocoding process and data requirements.
- Added repository-level `.gitignore` and `requirements.txt`.

## Highlights
- Implements **three-pass iterative geocoding**:
    1. Pass 1 — Geocode by **address + ZIP**.
    2. Pass 2 — Retry unmatched records.
    3. Pass 3 — Fallback to **city + state**.
- Unmatched records are automatically saved in **selection sets**.
- Uses the **Maptitude Tutorial dataset** (not included in repo).

## Requirements
- Python 3.9+
- Maptitude 2025 or newer
- `caliperpy` (install via `pip install -r requirements.txt`)
